### PR TITLE
Add workout and cardio models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# SportyPlanner
+
+An iOS sample application for planning workouts and cardio sessions. This version includes simple data models for workouts, exercises and cardio sessions. A `WorkoutPlanner` demonstrates how a local language model could generate a basic schedule.
+
+The project uses SwiftData for persistence and provides placeholder views to display workouts and cardio activities. Map support and HealthKit integration are left as future work.

--- a/SportyPlanner/CardioListView.swift
+++ b/SportyPlanner/CardioListView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import SwiftData
+
+struct CardioListView: View {
+    @Query private var sessions: [CardioSession]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sessions) { session in
+                    Text(session.type.rawValue.capitalized)
+                }
+            }
+            .navigationTitle("Cardio")
+        }
+    }
+}

--- a/SportyPlanner/CardioSession.swift
+++ b/SportyPlanner/CardioSession.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftData
+import CoreLocation
+
+@Model
+final class CardioSession {
+    enum ActivityType: String, Codable {
+        case running
+        case cycling
+    }
+
+    var type: ActivityType
+    var date: Date
+    var duration: TimeInterval
+    var locations: [CLLocation]
+
+    init(type: ActivityType, date: Date, duration: TimeInterval, locations: [CLLocation] = []) {
+        self.type = type
+        self.date = date
+        self.duration = duration
+        self.locations = locations
+    }
+}

--- a/SportyPlanner/ContentView.swift
+++ b/SportyPlanner/ContentView.swift
@@ -7,55 +7,33 @@
 
 import SwiftUI
 import SwiftData
+import MapKit
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    let planner = WorkoutPlanner()
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
-                }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+        TabView {
+            WorkoutListView()
+                .tabItem { Label("Workouts", systemImage: "dumbbell") }
+
+            CardioListView()
+                .tabItem { Label("Cardio", systemImage: "figure.run") }
+        }
+        .onAppear {
+            if try? modelContext.fetch(FetchDescriptor<Workout>()).isEmpty ?? true {
+                for workout in planner.generatePlan() {
+                    modelContext.insert(workout)
                 }
             }
-        } detail: {
-            Text("Select an item")
         }
     }
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
-        }
-    }
+    // Old list manipulation is removed in favour of dedicated views.
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
+        .modelContainer(for: [Item.self, Workout.self, Exercise.self, CardioSession.self], inMemory: true)
 }

--- a/SportyPlanner/Exercise.swift
+++ b/SportyPlanner/Exercise.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Exercise {
+    var name: String
+    var sets: Int
+    var reps: Int
+
+    init(name: String, sets: Int, reps: Int) {
+        self.name = name
+        self.sets = sets
+        self.reps = reps
+    }
+}

--- a/SportyPlanner/SportyPlannerApp.swift
+++ b/SportyPlanner/SportyPlannerApp.swift
@@ -13,6 +13,9 @@ struct SportyPlannerApp: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Item.self,
+            Workout.self,
+            Exercise.self,
+            CardioSession.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 

--- a/SportyPlanner/Workout.swift
+++ b/SportyPlanner/Workout.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Workout {
+    var name: String
+    var date: Date
+    var exercises: [Exercise]
+
+    init(name: String, date: Date, exercises: [Exercise] = []) {
+        self.name = name
+        self.date = date
+        self.exercises = exercises
+    }
+}

--- a/SportyPlanner/WorkoutListView.swift
+++ b/SportyPlanner/WorkoutListView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import SwiftData
+
+struct WorkoutListView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var workouts: [Workout]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(workouts) { workout in
+                    Text(workout.name)
+                }
+            }
+            .navigationTitle("Workouts")
+        }
+    }
+}

--- a/SportyPlanner/WorkoutPlanner.swift
+++ b/SportyPlanner/WorkoutPlanner.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Placeholder planner that would use a local LLM to generate a schedule.
+struct WorkoutPlanner {
+    /// Generates a simple plan of upcoming workouts.
+    func generatePlan() -> [Workout] {
+        // In a real implementation this would call a local LLM to generate the plan.
+        let exampleExercise = Exercise(name: "Push Ups", sets: 3, reps: 12)
+        let workout = Workout(name: "Example Workout", date: Date(), exercises: [exampleExercise])
+        return [workout]
+    }
+}

--- a/SportyPlannerTests/SportyPlannerTests.swift
+++ b/SportyPlannerTests/SportyPlannerTests.swift
@@ -10,8 +10,10 @@ import Testing
 
 struct SportyPlannerTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func plannerCreatesWorkout() async throws {
+        let planner = WorkoutPlanner()
+        let plan = planner.generatePlan()
+        #expect(plan.isEmpty == false)
     }
 
 }


### PR DESCRIPTION
## Summary
- add workout, cardio session, and exercise models
- show lists of workouts and cardio in a tab view
- integrate a placeholder `WorkoutPlanner` that simulates LLM planning
- update app schema and tests
- document the project in a new README

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_684de92588c4832283310b5812002c79