### PR TITLE
Fix CardioSession persistence issue

### DIFF
--- a/SportyPlanner/CardioSession.swift
+++ b/SportyPlanner/CardioSession.swift
@@ -2,6 +2,26 @@ import Foundation
 import SwiftData
 import CoreLocation
 
+/// Lightweight representation of a location that can be stored with SwiftData.
+struct TrackPoint: Codable, Hashable {
+    var latitude: Double
+    var longitude: Double
+
+    init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+
+    init(from location: CLLocation) {
+        self.latitude = location.coordinate.latitude
+        self.longitude = location.coordinate.longitude
+    }
+
+    var location: CLLocation {
+        CLLocation(latitude: latitude, longitude: longitude)
+    }
+}
+
 @Model
 final class CardioSession {
     enum ActivityType: String, Codable {
@@ -12,9 +32,9 @@ final class CardioSession {
     var type: ActivityType
     var date: Date
     var duration: TimeInterval
-    var locations: [CLLocation]
+    var locations: [TrackPoint]
 
-    init(type: ActivityType, date: Date, duration: TimeInterval, locations: [CLLocation] = []) {
+    init(type: ActivityType, date: Date, duration: TimeInterval, locations: [TrackPoint] = []) {
         self.type = type
         self.date = date
         self.duration = duration


### PR DESCRIPTION
## Summary
- make cardio route storable by introducing a `TrackPoint` struct
- update `CardioSession` to use `[TrackPoint]`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684deab9fee083229ec66d722636e6cd