### PR TITLE
Add Shortcuts intent for workout creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 An iOS sample application for planning workouts and cardio sessions. This version includes simple data models for workouts, exercises and cardio sessions. A `WorkoutPlanner` demonstrates how a local language model could generate a basic schedule.
 
 The project uses SwiftData for persistence and provides placeholder views to display workouts and cardio activities. Map support and HealthKit integration are left as future work.
+
+## Shortcuts Support
+
+SportyPlanner now provides an **Add Workout** intent that can be used from the Shortcuts app or via Siri to quickly create new workouts.

--- a/SportyPlanner/AddWorkoutIntent.swift
+++ b/SportyPlanner/AddWorkoutIntent.swift
@@ -1,0 +1,51 @@
+import AppIntents
+import SwiftData
+
+/// Intent to create a new workout so it can be triggered from Shortcuts or Siri.
+struct AddWorkoutIntent: AppIntent {
+    static var title: LocalizedStringResource = "Workout anlegen"
+    static var description = IntentDescription("Erstellt ein neues Workout in SportyPlanner.")
+
+    @Parameter(title: "Name")
+    var workoutName: String
+
+    @Parameter(title: "Datum")
+    var date: Date
+
+    @Parameter(title: "Übung", default: "")
+    var exerciseName: String
+
+    @Parameter(title: "Sätze", default: 3)
+    var sets: Int
+
+    @Parameter(title: "Wiederholungen", default: 10)
+    var reps: Int
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Workout \(\.$workoutName) am \(\.$date)") {
+            \.$exerciseName
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        let container = PersistenceController.shared.container
+        let context = ModelContext(container)
+
+        var exercises: [Exercise] = []
+        if !exerciseName.isEmpty {
+            exercises.append(Exercise(name: exerciseName, sets: sets, reps: reps))
+        }
+        let workout = Workout(name: workoutName, date: date, exercises: exercises)
+        context.insert(workout)
+        HealthKitManager.shared.saveWorkout(workout)
+        return .result(dialog: "Workout angelegt")
+    }
+}
+
+struct SportyPlannerShortcuts: AppShortcutsProvider {
+    static var shortcutTile = ShortcutTile("Workout anlegen", systemImageName: "plus")
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(intent: AddWorkoutIntent(), phrases: ["Workout in ^App anlegen", "Neues Workout \(.intent.workoutName) in ^App"])
+    }
+}

--- a/SportyPlanner/Persistence.swift
+++ b/SportyPlanner/Persistence.swift
@@ -1,0 +1,24 @@
+import SwiftData
+
+/// Provides a shared `ModelContainer` that can be used throughout the app and by
+/// App Intents.
+class PersistenceController {
+    static let shared = PersistenceController()
+    let container: ModelContainer
+
+    private init() {
+        let schema = Schema([
+            Workout.self,
+            Exercise.self,
+            CardioSession.self,
+        ])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        do {
+            container = try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            print("ModelContainer could not be loaded: \(error). Using in-memory store as fallback.")
+            let memoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+            container = try! ModelContainer(for: schema, configurations: [memoryConfig])
+        }
+    }
+}

--- a/SportyPlanner/SportyPlannerApp.swift
+++ b/SportyPlanner/SportyPlannerApp.swift
@@ -5,29 +5,6 @@ import SwiftData
 struct SportyPlannerApp: App {
     @State private var showingSplash = true
 
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Workout.self,
-            Exercise.self,
-            CardioSession.self,
-        ])
-
-        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            return try ModelContainer(for: schema, configurations: [configuration])
-        } catch {
-            // If the persistent store cannot be loaded (e.g. after a model change),
-            // fall back to an in-memory container so the app can still run.
-            print("ModelContainer could not be loaded: \(error). Using in-memory store as fallback.")
-            let memoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-            do {
-                return try ModelContainer(for: schema, configurations: [memoryConfig])
-            } catch {
-                fatalError("Could not create in-memory ModelContainer: \(error)")
-            }
-        }
-    }()
 
     var body: some Scene {
         WindowGroup {
@@ -45,7 +22,7 @@ struct SportyPlannerApp: App {
                     .onAppear(perform: requestHealthKitAccess)
             }
         }
-        .modelContainer(sharedModelContainer)
+        .modelContainer(PersistenceController.shared.container)
     }
     
     private func requestHealthKitAccess() {


### PR DESCRIPTION
## Summary
- add `PersistenceController` for a global `ModelContainer`
- integrate the new persistence container in `SportyPlannerApp`
- expose `AddWorkoutIntent` so workouts can be created via Shortcuts
- document Shortcuts support in the README

## Testing
- `swift test --list-tests` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a29d5a083229948f276d6c8cdd8