### PR TITLE
Fix ExerciseEntity errors

### DIFF
--- a/SportyPlanner/ExerciseEntity.swift
+++ b/SportyPlanner/ExerciseEntity.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Struct representing a single exercise that can be used with Shortcuts.
 /// The properties are simple stored values so the type remains `Sendable`.
-struct ExerciseEntity: AppEntity, Identifiable, Hashable, Sendable {
+struct ExerciseEntity: AppEntity, Identifiable, Hashable, Sendable, Codable {
     /// Unique identifier used by Shortcuts.
     let id: UUID
 
@@ -17,16 +17,19 @@ struct ExerciseEntity: AppEntity, Identifiable, Hashable, Sendable {
     var reps: Int
 
     /// How the type itself is shown in the Shortcuts UI.
-    nonisolated(unsafe) static var typeDisplayRepresentation: TypeDisplayRepresentation = "Exercise"
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Exercise")
 
     /// Representation for a concrete value when shown in Shortcuts.
     var displayRepresentation: DisplayRepresentation {
-        DisplayRepresentation(title: name, subtitle: "\(sets) sets x \(reps) reps")
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: name),
+            subtitle: LocalizedStringResource(stringLiteral: "\(sets) sets x \(reps) reps")
+        )
     }
 
     /// Default query used by the Shortcuts app.
-    nonisolated(unsafe) static var defaultQuery = ExerciseQuery()
-    nonisolated(unsafe) static var typeDisplayName: LocalizedStringResource = "Exercise"
+    static var defaultQuery = ExerciseQuery()
+    static var typeDisplayName: LocalizedStringResource = "Exercise"
 
     init(id: UUID = UUID(), name: String, sets: Int, reps: Int) {
         self.id = id


### PR DESCRIPTION
## Summary
- make ExerciseEntity conform to `Codable` and update type display helpers
- convert string properties to `LocalizedStringResource`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f2d9dc308832282ed3df7b283768f